### PR TITLE
add  object_msgs in find_package

### DIFF
--- a/people_msgs/CMakeLists.txt
+++ b/people_msgs/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   geometry_msgs
   message_generation
+  object_msgs
 )
 
 add_message_files(DIRECTORY msg FILES


### PR DESCRIPTION
to solve CMake Error at /opt/ros/kinetic/share/genmsg/cmake/genmsg-extras.cmake:263 (message):
  Messages depends on unknown pkg: object_msgs (Missing
  'find_package(object_msgs)'?)