### PR TITLE
people_msgs package name is changed to vino_people_msgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,17 @@ Currently, the inference feature list is supported:
 - Face Detection:
 ```/ros_openvino_toolkit/face_detection```([object_msgs::ObjectsInBoxes](https://github.com/intel/object_msgs/blob/master/msg/ObjectsInBoxes.msg))
 - Emotion Recognition:
-```/ros_openvino_toolkit/emotions_recognition```([people_msgs::EmotionsStamped](https://github.com/intel/ros_openvino_toolkit/blob/master/people_msgs/msg/EmotionsStamped.msg))
+```/ros_openvino_toolkit/emotions_recognition```([vino_people_msgs::EmotionsStamped](https://github.com/intel/ros_openvino_toolkit/blob/master/vino_people_msgs/msg/EmotionsStamped.msg))
 - Age and Gender Recognition:
-```/ros_openvino_toolkit/age_genders_Recognition```([people_msgs::AgeGenderStamped](https://github.com/intel/ros_openvino_toolkit/blob/master/people_msgs/msg/AgeGenderStamped.msg))
+```/ros_openvino_toolkit/age_genders_Recognition```([vino_people_msgs::AgeGenderStamped](https://github.com/intel/ros_openvino_toolkit/blob/master/vino_people_msgs/msg/AgeGenderStamped.msg))
 - Head Pose Estimation:
-```/ros_openvino_toolkit/headposes_estimation```([people_msgs::HeadPoseStamped](https://github.com/intel/ros_openvino_toolkit/blob/master/people_msgs/msg/HeadPoseStamped.msg))
+```/ros_openvino_toolkit/headposes_estimation```([vino_people_msgs::HeadPoseStamped](https://github.com/intel/ros_openvino_toolkit/blob/master/vino_people_msgs/msg/HeadPoseStamped.msg))
 - Object Detection:
 ```/ros_openvino_toolkit/detected_objects```([object_msgs::ObjectsInBoxes](https://github.com/intel/object_msgs/blob/master/msg/ObjectsInBoxes.msg))
 - Object Segmentation:
-```/ros_openvino_toolkit/segmented_obejcts```([people_msgs::ObjectsInMasks](https://github.com/intel/ros_openvino_toolkit/blob/devel/people_msgs/msg/ObjectsInMasks.msg))
+```/ros_openvino_toolkit/segmented_obejcts```([vino_people_msgs::ObjectsInMasks](https://github.com/intel/ros_openvino_toolkit/blob/devel/vino_people_msgs/msg/ObjectsInMasks.msg))
 - Person Reidentification:
-```/ros_openvino_toolkit/reidentified_persons```([people_msgs::ReidentificationStamped](https://github.com/intel/ros_openvino_toolkit/blob/devel/people_msgs/msg/ReidentificationStamped.msg))
+```/ros_openvino_toolkit/reidentified_persons```([vino_people_msgs::ReidentificationStamped](https://github.com/intel/ros_openvino_toolkit/blob/devel/vino_people_msgs/msg/ReidentificationStamped.msg))
 - Rviz Output:
 ```/ros_openvino_toolkit/image_rviz```([sensor_msgs::Image](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/Image.html))
 
@@ -88,11 +88,11 @@ Currently, the inference feature list is supported:
 - Face Detection Service:
 ```/detect_face``` ([object_msgs::DetectObject](https://github.com/intel/object_msgs/blob/master/srv/DetectObject.srv))
 - Age & Gender Detection Service:
-```/detect_age_gender``` ([people_msgs::AgeGender](https://github.com/intel/ros_openvino_toolkit/blob/master/people_msgs/srv/AgeGenderSrv.srv))
+```/detect_age_gender``` ([vino_people_msgs::AgeGender](https://github.com/intel/ros_openvino_toolkit/blob/master/vino_people_msgs/srv/AgeGenderSrv.srv))
 - Headpose Detection Service:
-```/detect_head_pose``` ([people_msgs::HeadPose](https://github.com/intel/ros_openvino_toolkit/blob/master/people_msgs/srv/HeadPoseSrv.srv))
+```/detect_head_pose``` ([vino_people_msgs::HeadPose](https://github.com/intel/ros_openvino_toolkit/blob/master/vino_people_msgs/srv/HeadPoseSrv.srv))
 - Emotion Detection Service:
-```/detect_emotion``` ([people_msgs::Emotion](https://github.com/intel/ros_openvino_toolkit/blob/master/people_msgs/srv/EmotionSrv.srv))
+```/detect_emotion``` ([vino_people_msgs::Emotion](https://github.com/intel/ros_openvino_toolkit/blob/master/vino_people_msgs/srv/EmotionSrv.srv))
 
 
 ### RViz

--- a/dynamic_vino_lib/CMakeLists.txt
+++ b/dynamic_vino_lib/CMakeLists.txt
@@ -29,7 +29,7 @@ find_package(
   std_msgs
   sensor_msgs
   object_msgs
-  people_msgs
+  vino_people_msgs
   image_transport
   cv_bridge
   InferenceEngine

--- a/dynamic_vino_lib/include/dynamic_vino_lib/outputs/base_output.h
+++ b/dynamic_vino_lib/include/dynamic_vino_lib/outputs/base_output.h
@@ -115,17 +115,17 @@ class BaseOutput
   virtual void setServiceResponseForFace(
     boost::shared_ptr<object_msgs::DetectObjectResponse> response) {}
   virtual void setServiceResponse(
-    boost::shared_ptr<people_msgs::AgeGenderSrvResponse> response) {}
+    boost::shared_ptr<vino_people_msgs::AgeGenderSrvResponse> response) {}
   virtual void setServiceResponse(
-    boost::shared_ptr<people_msgs::EmotionSrvResponse> response) {}
+    boost::shared_ptr<vino_people_msgs::EmotionSrvResponse> response) {}
   virtual void setServiceResponse(
-    boost::shared_ptr<people_msgs::HeadPoseSrvResponse> response) {}
+    boost::shared_ptr<vino_people_msgs::HeadPoseSrvResponse> response) {}
   virtual void setServiceResponse(
-    boost::shared_ptr<people_msgs::PeopleSrvResponse> response) {}
+    boost::shared_ptr<vino_people_msgs::PeopleSrvResponse> response) {}
   virtual void setServiceResponse(
-    boost::shared_ptr<people_msgs::ReidentificationSrvResponse> response) {}
+    boost::shared_ptr<vino_people_msgs::ReidentificationSrvResponse> response) {}
   virtual void setServiceResponse(
-    boost::shared_ptr<people_msgs::ObjectsInMasksSrvResponse> response) {}
+    boost::shared_ptr<vino_people_msgs::ObjectsInMasksSrvResponse> response) {}
   Pipeline* getPipeline() const;
   cv::Mat getFrame() const;
   virtual void clearData() {}

--- a/dynamic_vino_lib/include/dynamic_vino_lib/outputs/ros_service_output.h
+++ b/dynamic_vino_lib/include/dynamic_vino_lib/outputs/ros_service_output.h
@@ -23,24 +23,24 @@
 #include <object_msgs/Object.h>
 #include <object_msgs/ObjectInBox.h>
 #include <object_msgs/ObjectsInBoxes.h>
-#include <people_msgs/Emotion.h>
-#include <people_msgs/EmotionsStamped.h>
-#include <people_msgs/AgeGender.h>
-#include <people_msgs/AgeGenderStamped.h>
-#include <people_msgs/HeadPose.h>
-#include <people_msgs/HeadPoseStamped.h>
-#include <people_msgs/ObjectInMask.h>
-#include <people_msgs/ObjectsInMasks.h>
-#include <people_msgs/Reidentification.h>
-#include <people_msgs/ReidentificationStamped.h>
+#include <vino_people_msgs/Emotion.h>
+#include <vino_people_msgs/EmotionsStamped.h>
+#include <vino_people_msgs/AgeGender.h>
+#include <vino_people_msgs/AgeGenderStamped.h>
+#include <vino_people_msgs/HeadPose.h>
+#include <vino_people_msgs/HeadPoseStamped.h>
+#include <vino_people_msgs/ObjectInMask.h>
+#include <vino_people_msgs/ObjectsInMasks.h>
+#include <vino_people_msgs/Reidentification.h>
+#include <vino_people_msgs/ReidentificationStamped.h>
 
-#include <people_msgs/AgeGenderSrv.h>
-#include <people_msgs/EmotionSrv.h>
-#include <people_msgs/HeadPoseSrv.h>
-#include <people_msgs/PeopleSrv.h>
+#include <vino_people_msgs/AgeGenderSrv.h>
+#include <vino_people_msgs/EmotionSrv.h>
+#include <vino_people_msgs/HeadPoseSrv.h>
+#include <vino_people_msgs/PeopleSrv.h>
 #include <object_msgs/DetectObject.h>
-#include <people_msgs/ObjectsInMasksSrv.h>
-#include <people_msgs/ReidentificationSrv.h>
+#include <vino_people_msgs/ObjectsInMasksSrv.h>
+#include <vino_people_msgs/ReidentificationSrv.h>
 
 
 #include <std_msgs/Header.h>
@@ -72,12 +72,12 @@ public:
 
   void setServiceResponse(boost::shared_ptr<object_msgs::DetectObject::Response> response);
   void setResponseForFace(boost::shared_ptr<object_msgs::DetectObject::Response> response);
-  void setServiceResponse(boost::shared_ptr<people_msgs::AgeGenderSrv::Response> response);
-  void setServiceResponse(boost::shared_ptr<people_msgs::EmotionSrv::Response> response);
-  void setServiceResponse(boost::shared_ptr<people_msgs::HeadPoseSrv::Response> response);
-  void setServiceResponse(boost::shared_ptr<people_msgs::PeopleSrv::Response> response);
-  void setServiceResponse(boost::shared_ptr<people_msgs::ObjectsInMasksSrv::Response> response);
-  void setServiceResponse(boost::shared_ptr<people_msgs::ReidentificationSrv::Response> response);
+  void setServiceResponse(boost::shared_ptr<vino_people_msgs::AgeGenderSrv::Response> response);
+  void setServiceResponse(boost::shared_ptr<vino_people_msgs::EmotionSrv::Response> response);
+  void setServiceResponse(boost::shared_ptr<vino_people_msgs::HeadPoseSrv::Response> response);
+  void setServiceResponse(boost::shared_ptr<vino_people_msgs::PeopleSrv::Response> response);
+  void setServiceResponse(boost::shared_ptr<vino_people_msgs::ObjectsInMasksSrv::Response> response);
+  void setServiceResponse(boost::shared_ptr<vino_people_msgs::ReidentificationSrv::Response> response);
 
 private:
   const std::string service_name_;

--- a/dynamic_vino_lib/include/dynamic_vino_lib/outputs/ros_topic_output.h
+++ b/dynamic_vino_lib/include/dynamic_vino_lib/outputs/ros_topic_output.h
@@ -26,16 +26,16 @@
 #include <object_msgs/Object.h>
 #include <object_msgs/ObjectInBox.h>
 #include <object_msgs/ObjectsInBoxes.h>
-#include <people_msgs/AgeGender.h>
-#include <people_msgs/AgeGenderStamped.h>
-#include <people_msgs/Emotion.h>
-#include <people_msgs/EmotionsStamped.h>
-#include <people_msgs/HeadPose.h>
-#include <people_msgs/HeadPoseStamped.h>
-#include <people_msgs/ObjectInMask.h>
-#include <people_msgs/ObjectsInMasks.h>
-#include <people_msgs/Reidentification.h>
-#include <people_msgs/ReidentificationStamped.h>
+#include <vino_people_msgs/AgeGender.h>
+#include <vino_people_msgs/AgeGenderStamped.h>
+#include <vino_people_msgs/Emotion.h>
+#include <vino_people_msgs/EmotionsStamped.h>
+#include <vino_people_msgs/HeadPose.h>
+#include <vino_people_msgs/HeadPoseStamped.h>
+#include <vino_people_msgs/ObjectInMask.h>
+#include <vino_people_msgs/ObjectsInMasks.h>
+#include <vino_people_msgs/Reidentification.h>
+#include <vino_people_msgs/ReidentificationStamped.h>
 #include <ros/ros.h>
 
 #include <memory>
@@ -119,17 +119,17 @@ class RosTopicOutput : public BaseOutput
   ros::Publisher pub_face_;
   std::shared_ptr<object_msgs::ObjectsInBoxes> faces_msg_ptr_;
   ros::Publisher pub_emotion_;
-  std::shared_ptr<people_msgs::EmotionsStamped> emotions_msg_ptr_;
+  std::shared_ptr<vino_people_msgs::EmotionsStamped> emotions_msg_ptr_;
   ros::Publisher pub_age_gender_;
-  std::shared_ptr<people_msgs::AgeGenderStamped> age_gender_msg_ptr_;
+  std::shared_ptr<vino_people_msgs::AgeGenderStamped> age_gender_msg_ptr_;
   ros::Publisher pub_headpose_;
-  std::shared_ptr<people_msgs::HeadPoseStamped> headpose_msg_ptr_;
+  std::shared_ptr<vino_people_msgs::HeadPoseStamped> headpose_msg_ptr_;
   ros::Publisher pub_object_;
   std::shared_ptr<object_msgs::ObjectsInBoxes> object_msg_ptr_;
   ros::Publisher pub_person_reid_;
-  std::shared_ptr<people_msgs::ReidentificationStamped> person_reid_msg_ptr_;
+  std::shared_ptr<vino_people_msgs::ReidentificationStamped> person_reid_msg_ptr_;
   ros::Publisher pub_segmented_object_;
-  std::shared_ptr<people_msgs::ObjectsInMasks> segmented_object_msg_ptr_;
+  std::shared_ptr<vino_people_msgs::ObjectsInMasks> segmented_object_msg_ptr_;
 
 };
 }  // namespace Outputs

--- a/dynamic_vino_lib/include/dynamic_vino_lib/services/frame_processing_server.h
+++ b/dynamic_vino_lib/include/dynamic_vino_lib/services/frame_processing_server.h
@@ -17,20 +17,20 @@
 #include <object_msgs/Object.h>
 #include <object_msgs/ObjectInBox.h>
 #include <object_msgs/ObjectsInBoxes.h>
-#include <people_msgs/Emotion.h>
-#include <people_msgs/EmotionsStamped.h>
-#include <people_msgs/AgeGender.h>
-#include <people_msgs/AgeGenderStamped.h>
-#include <people_msgs/HeadPose.h>
-#include <people_msgs/HeadPoseStamped.h>
+#include <vino_people_msgs/Emotion.h>
+#include <vino_people_msgs/EmotionsStamped.h>
+#include <vino_people_msgs/AgeGender.h>
+#include <vino_people_msgs/AgeGenderStamped.h>
+#include <vino_people_msgs/HeadPose.h>
+#include <vino_people_msgs/HeadPoseStamped.h>
 
-#include <people_msgs/AgeGenderSrv.h>
-#include <people_msgs/EmotionSrv.h>
-#include <people_msgs/HeadPoseSrv.h>
-#include <people_msgs/PeopleSrv.h>
+#include <vino_people_msgs/AgeGenderSrv.h>
+#include <vino_people_msgs/EmotionSrv.h>
+#include <vino_people_msgs/HeadPoseSrv.h>
+#include <vino_people_msgs/PeopleSrv.h>
 #include <object_msgs/DetectObject.h>
-#include <people_msgs/ObjectsInMasksSrv.h>
-#include <people_msgs/ReidentificationSrv.h>
+#include <vino_people_msgs/ObjectsInMasksSrv.h>
+#include <vino_people_msgs/ReidentificationSrv.h>
 
 #include <ros/ros.h>
 #include <memory>

--- a/dynamic_vino_lib/package.xml
+++ b/dynamic_vino_lib/package.xml
@@ -32,7 +32,7 @@ limitations under the License.
   <build_depend>image_transport</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>object_msgs</build_depend>
-  <build_depend>people_msgs</build_depend>
+  <build_depend>vino_people_msgs</build_depend>
   <build_depend>vino_param_lib</build_depend>
 
   <run_depend>roscpp</run_depend>
@@ -42,6 +42,6 @@ limitations under the License.
   <run_depend>image_transport</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>object_msgs</run_depend>
-  <run_depend>people_msgs</run_depend>
+  <run_depend>vino_people_msgs</run_depend>
   <run_depend>vino_param_lib</run_depend>
 </package>

--- a/dynamic_vino_lib/src/outputs/ros_service_output.cpp
+++ b/dynamic_vino_lib/src/outputs/ros_service_output.cpp
@@ -51,7 +51,7 @@ void Outputs::RosServiceOutput::setResponseForFace(
 }
 
 void Outputs::RosServiceOutput::setServiceResponse(
-  boost::shared_ptr<people_msgs::AgeGenderSrv::Response> response)
+  boost::shared_ptr<vino_people_msgs::AgeGenderSrv::Response> response)
 {
   if (age_gender_msg_ptr_ != nullptr) {
     response->age_gender.objects = age_gender_msg_ptr_->objects;
@@ -59,7 +59,7 @@ void Outputs::RosServiceOutput::setServiceResponse(
 }
 
 void Outputs::RosServiceOutput::setServiceResponse(
-  boost::shared_ptr<people_msgs::EmotionSrv::Response> response)
+  boost::shared_ptr<vino_people_msgs::EmotionSrv::Response> response)
 {
   if (emotions_msg_ptr_ != nullptr) {
     response->emotion.emotions = emotions_msg_ptr_->emotions;
@@ -67,7 +67,7 @@ void Outputs::RosServiceOutput::setServiceResponse(
 }
 
 void Outputs::RosServiceOutput::setServiceResponse(
-  boost::shared_ptr<people_msgs::HeadPoseSrv::Response> response)
+  boost::shared_ptr<vino_people_msgs::HeadPoseSrv::Response> response)
 {
   if (headpose_msg_ptr_ != nullptr) {
     response->headpose.headposes = headpose_msg_ptr_->headposes;
@@ -75,7 +75,7 @@ void Outputs::RosServiceOutput::setServiceResponse(
 }
 
 void Outputs::RosServiceOutput::setServiceResponse(
-  boost::shared_ptr<people_msgs::ObjectsInMasksSrv::Response> response)
+  boost::shared_ptr<vino_people_msgs::ObjectsInMasksSrv::Response> response)
   {
     slog::info << "in ObjectsInMasks service::Response ...";
     if (segmented_object_msg_ptr_ != nullptr) {
@@ -83,7 +83,7 @@ void Outputs::RosServiceOutput::setServiceResponse(
     }
   }
 void Outputs::RosServiceOutput::setServiceResponse(
-  boost::shared_ptr<people_msgs::ReidentificationSrv::Response> response)
+  boost::shared_ptr<vino_people_msgs::ReidentificationSrv::Response> response)
   {
     slog::info << "in Reidentification service::Response ...";
     if (person_reid_msg_ptr_ != nullptr) {
@@ -92,7 +92,7 @@ void Outputs::RosServiceOutput::setServiceResponse(
   }
 
 void Outputs::RosServiceOutput::setServiceResponse(
-  boost::shared_ptr<people_msgs::PeopleSrv::Response> response)
+  boost::shared_ptr<vino_people_msgs::PeopleSrv::Response> response)
 {
   slog::info << "in People::Response ...";
   if (faces_msg_ptr_ != nullptr) {

--- a/dynamic_vino_lib/src/outputs/ros_topic_output.cpp
+++ b/dynamic_vino_lib/src/outputs/ros_topic_output.cpp
@@ -29,17 +29,17 @@ Outputs::RosTopicOutput::RosTopicOutput()
 {
   pub_face_ =
       nh_.advertise<object_msgs::ObjectsInBoxes>("/openvino_toolkit/faces", 16);
-  pub_emotion_ = nh_.advertise<people_msgs::EmotionsStamped>(
+  pub_emotion_ = nh_.advertise<vino_people_msgs::EmotionsStamped>(
       "/openvino_toolkit/emotions", 16);
-  pub_age_gender_ = nh_.advertise<people_msgs::AgeGenderStamped>(
+  pub_age_gender_ = nh_.advertise<vino_people_msgs::AgeGenderStamped>(
       "/openvino_toolkit/age_genders", 16);
-  pub_headpose_ = nh_.advertise<people_msgs::HeadPoseStamped>(
+  pub_headpose_ = nh_.advertise<vino_people_msgs::HeadPoseStamped>(
       "/openvino_toolkit/headposes", 16);
   pub_object_ = nh_.advertise<object_msgs::ObjectsInBoxes>(
       "/openvino_toolkit/detected_objects", 16);
-  pub_person_reid_ = nh_.advertise<people_msgs::ReidentificationStamped>(
+  pub_person_reid_ = nh_.advertise<vino_people_msgs::ReidentificationStamped>(
       "/openvino_toolkit/reidentified_persons", 16);
-  pub_segmented_object_ = nh_.advertise<people_msgs::ObjectsInMasks>(
+  pub_segmented_object_ = nh_.advertise<vino_people_msgs::ObjectsInMasks>(
       "/openvino_toolkit/segmented_obejcts", 16);
 
   emotions_msg_ptr_ = NULL;
@@ -57,8 +57,8 @@ void Outputs::RosTopicOutput::feedFrame(const cv::Mat& frame) {}
 void Outputs::RosTopicOutput::accept(
   const std::vector<dynamic_vino_lib::PersonReidentificationResult> & results)
 {
-  person_reid_msg_ptr_ = std::make_shared<people_msgs::ReidentificationStamped>();
-  people_msgs::Reidentification person;
+  person_reid_msg_ptr_ = std::make_shared<vino_people_msgs::ReidentificationStamped>();
+  vino_people_msgs::Reidentification person;
   for (auto & r : results) {
     // slog::info << ">";
     auto loc = r.getLocation();
@@ -74,8 +74,8 @@ void Outputs::RosTopicOutput::accept(
 void Outputs::RosTopicOutput::accept(
   const std::vector<dynamic_vino_lib::ObjectSegmentationResult> & results)
 {
-  segmented_object_msg_ptr_ = std::make_shared<people_msgs::ObjectsInMasks>();
-  people_msgs::ObjectInMask object;
+  segmented_object_msg_ptr_ = std::make_shared<vino_people_msgs::ObjectsInMasks>();
+  vino_people_msgs::ObjectInMask object;
   for (auto & r : results) {
     // slog::info << ">";
     auto loc = r.getLocation();
@@ -118,9 +118,9 @@ void Outputs::RosTopicOutput::accept(
 void Outputs::RosTopicOutput::accept(
     const std::vector<dynamic_vino_lib::EmotionsResult>& results)
 {
-  emotions_msg_ptr_ = std::make_shared<people_msgs::EmotionsStamped>();
+  emotions_msg_ptr_ = std::make_shared<vino_people_msgs::EmotionsStamped>();
 
-  people_msgs::Emotion emotion;
+  vino_people_msgs::Emotion emotion;
   for (auto r : results)
   {
     auto loc = r.getLocation();
@@ -136,9 +136,9 @@ void Outputs::RosTopicOutput::accept(
 void Outputs::RosTopicOutput::accept(
     const std::vector<dynamic_vino_lib::AgeGenderResult>& results)
 {
-  age_gender_msg_ptr_ = std::make_shared<people_msgs::AgeGenderStamped>();
+  age_gender_msg_ptr_ = std::make_shared<vino_people_msgs::AgeGenderStamped>();
 
-  people_msgs::AgeGender ag;
+  vino_people_msgs::AgeGender ag;
   for (auto r : results)
   {
     auto loc = r.getLocation();
@@ -165,9 +165,9 @@ void Outputs::RosTopicOutput::accept(
 void Outputs::RosTopicOutput::accept(
     const std::vector<dynamic_vino_lib::HeadPoseResult>& results)
 {
-  headpose_msg_ptr_ = std::make_shared<people_msgs::HeadPoseStamped>();
+  headpose_msg_ptr_ = std::make_shared<vino_people_msgs::HeadPoseStamped>();
 
-  people_msgs::HeadPose hp;
+  vino_people_msgs::HeadPose hp;
   for (auto r : results)
   {
     auto loc = r.getLocation();
@@ -205,7 +205,7 @@ void Outputs::RosTopicOutput::handleOutput()
 {
   std_msgs::Header header = getHeader();
   if (person_reid_msg_ptr_ != nullptr) {
-    people_msgs::ReidentificationStamped person_reid_msg;
+    vino_people_msgs::ReidentificationStamped person_reid_msg;
     person_reid_msg.header = header;
     person_reid_msg.reidentified_vector.swap(person_reid_msg_ptr_->reidentified_vector);
     pub_person_reid_.publish(person_reid_msg);
@@ -213,7 +213,7 @@ void Outputs::RosTopicOutput::handleOutput()
   }
   if (segmented_object_msg_ptr_ != nullptr) {
     // slog::info << "publishing faces outputs." << slog::endl;
-    people_msgs::ObjectsInMasks segmented_msg;
+    vino_people_msgs::ObjectsInMasks segmented_msg;
     segmented_msg.header = header;
     segmented_msg.objects_vector.swap(segmented_object_msg_ptr_->objects_vector);
     pub_segmented_object_.publish(segmented_msg);
@@ -230,7 +230,7 @@ void Outputs::RosTopicOutput::handleOutput()
   }
   if (emotions_msg_ptr_ != nullptr)
   {
-    people_msgs::EmotionsStamped emotions_msg;
+    vino_people_msgs::EmotionsStamped emotions_msg;
     emotions_msg.header = header;
     emotions_msg.emotions.swap(emotions_msg_ptr_->emotions);
 
@@ -239,7 +239,7 @@ void Outputs::RosTopicOutput::handleOutput()
   }
   if (age_gender_msg_ptr_ != nullptr)
   {
-    people_msgs::AgeGenderStamped age_gender_msg;
+    vino_people_msgs::AgeGenderStamped age_gender_msg;
     age_gender_msg.header = header;
     age_gender_msg.objects.swap(age_gender_msg_ptr_->objects);
 
@@ -248,7 +248,7 @@ void Outputs::RosTopicOutput::handleOutput()
   }
   if (headpose_msg_ptr_ != nullptr)
   {
-    people_msgs::HeadPoseStamped headpose_msg;
+    vino_people_msgs::HeadPoseStamped headpose_msg;
     headpose_msg.header = header;
     headpose_msg.headposes.swap(headpose_msg_ptr_->headposes);
 

--- a/dynamic_vino_lib/src/services/frame_processing_server.cpp
+++ b/dynamic_vino_lib/src/services/frame_processing_server.cpp
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "dynamic_vino_lib/services/frame_processing_server.h"
-#include <people_msgs/PeopleSrv.h>
-#include <people_msgs/ObjectsInMasksSrv.h>
-#include <people_msgs/ReidentificationSrv.h>
+#include <vino_people_msgs/PeopleSrv.h>
+#include <vino_people_msgs/ObjectsInMasksSrv.h>
+#include <vino_people_msgs/ReidentificationSrv.h>
 #include <object_msgs/DetectObject.h>
 #include <vino_param_lib/param_manager.h>
 #include <ros/ros.h>
@@ -96,7 +96,7 @@ bool FrameProcessingServer<T>::cbService(
 }
 
 template class FrameProcessingServer<object_msgs::DetectObject>;
-template class FrameProcessingServer<people_msgs::PeopleSrv>;
-template class FrameProcessingServer<people_msgs::ReidentificationSrv>;
-template class FrameProcessingServer<people_msgs::ObjectsInMasksSrv>;
+template class FrameProcessingServer<vino_people_msgs::PeopleSrv>;
+template class FrameProcessingServer<vino_people_msgs::ReidentificationSrv>;
+template class FrameProcessingServer<vino_people_msgs::ObjectsInMasksSrv>;
 }  // namespace vino_service

--- a/people_msgs/CMakeLists.txt
+++ b/people_msgs/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 2.8.3)
 
-project(people_msgs)
+project(vino_people_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
   std_msgs

--- a/people_msgs/msg/AgeGenderStamped.msg
+++ b/people_msgs/msg/AgeGenderStamped.msg
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 std_msgs/Header header
-people_msgs/AgeGender[] objects
+vino_people_msgs/AgeGender[] objects

--- a/people_msgs/msg/EmotionsStamped.msg
+++ b/people_msgs/msg/EmotionsStamped.msg
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 std_msgs/Header header
-people_msgs/Emotion[] emotions
+vino_people_msgs/Emotion[] emotions

--- a/people_msgs/msg/HeadPoseStamped.msg
+++ b/people_msgs/msg/HeadPoseStamped.msg
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 std_msgs/Header header
-people_msgs/HeadPose[] headposes
+vino_people_msgs/HeadPose[] headposes

--- a/people_msgs/msg/PersonsStamped.msg
+++ b/people_msgs/msg/PersonsStamped.msg
@@ -14,6 +14,6 @@
 
 std_msgs/Header header
 object_msgs/ObjectInBox[] faces
-people_msgs/Emotion[] emotions
-people_msgs/AgeGender[] agegenders
-people_msgs/HeadPose[] headposes
+vino_people_msgs/Emotion[] emotions
+vino_people_msgs/AgeGender[] agegenders
+vino_people_msgs/HeadPose[] headposes

--- a/people_msgs/package.xml
+++ b/people_msgs/package.xml
@@ -14,7 +14,7 @@ limitations under the License.
 -->
 
 <package>
-  <name>people_msgs</name>
+  <name>vino_people_msgs</name>
   <version>0.3.0</version>
   <description>A package containing people message definitions.</description>
   <author email="wei.zhi.liu@intel.com">Weizhi Liu</author>

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(
   roslint
   cv_bridge
   object_msgs
-  people_msgs
+  vino_people_msgs
   vino_param_lib
   dynamic_vino_lib
 )

--- a/sample/package.xml
+++ b/sample/package.xml
@@ -33,7 +33,7 @@ limitations under the License.
   <build_depend>vino_param_lib</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>object_msgs</build_depend>
-  <build_depend>people_msgs</build_depend>
+  <build_depend>vino_people_msgs</build_depend>
  
   <run_depend>roscpp</run_depend>
   <run_depend>roslint</run_depend>
@@ -43,5 +43,5 @@ limitations under the License.
   <run_depend>dynamic_vino_lib</run_depend>
   <run_depend>vino_param_lib</run_depend>
   <run_depend>object_msgs</run_depend>
-  <run_depend>people_msgs</run_depend>
+  <run_depend>vino_people_msgs</run_depend>
 </package>

--- a/sample/src/image_people_client.cpp
+++ b/sample/src/image_people_client.cpp
@@ -23,7 +23,7 @@
 #include <ros/package.h>
 #include <ros/ros.h>
 
-#include <people_msgs/PeopleSrv.h>
+#include <vino_people_msgs/PeopleSrv.h>
 
 
 
@@ -39,9 +39,9 @@ int main(int argc, char ** argv)
   }
 
 
-  ros::ServiceClient client = n.serviceClient<people_msgs::PeopleSrv>("/openvino_toolkit/service");
+  ros::ServiceClient client = n.serviceClient<vino_people_msgs::PeopleSrv>("/openvino_toolkit/service");
 
-  people_msgs::PeopleSrv srv;
+  vino_people_msgs::PeopleSrv srv;
 
   if (client.call(srv))
   {

--- a/sample/src/image_people_server.cpp
+++ b/sample/src/image_people_server.cpp
@@ -89,7 +89,7 @@ int main(int argc, char** argv)
   slog::info << "service name=" << service_name << slog::endl;
 
   auto node = std::make_shared<vino_service::FrameProcessingServer
-    <people_msgs::PeopleSrv>>(service_name, FLAGS_config);
+    <vino_people_msgs::PeopleSrv>>(service_name, FLAGS_config);
   
   slog::info << "Waiting for service request..." << slog::endl;
   

--- a/sample/src/image_reidentification_client.cpp
+++ b/sample/src/image_reidentification_client.cpp
@@ -24,7 +24,7 @@
 #include <ros/ros.h>
 #include "opencv2/opencv.hpp"
 
-#include <people_msgs/ReidentificationSrv.h>
+#include <vino_people_msgs/ReidentificationSrv.h>
 
 
 
@@ -34,10 +34,10 @@ int main(int argc, char ** argv)
 
   ros::NodeHandle n;
 
-  ros::ServiceClient client = n.serviceClient<people_msgs::ReidentificationSrv>("/openvino_toolkit/service");
+  ros::ServiceClient client = n.serviceClient<vino_people_msgs::ReidentificationSrv>("/openvino_toolkit/service");
 
 
-  people_msgs::ReidentificationSrv srv;
+  vino_people_msgs::ReidentificationSrv srv;
 
   if (client.call(srv))
   {

--- a/sample/src/image_reidentification_server.cpp
+++ b/sample/src/image_reidentification_server.cpp
@@ -58,7 +58,7 @@
 #include "inference_engine.hpp"
 #include "opencv2/opencv.hpp"
 #include "sample/utility.hpp"
-#include <people_msgs/ReidentificationSrv.h>
+#include <vino_people_msgs/ReidentificationSrv.h>
 
 
 bool parseAndCheckCommandLine(int argc, char** argv)
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
 
 
   auto node = std::make_shared<vino_service::FrameProcessingServer
-    <people_msgs::ReidentificationSrv>>(service_name, FLAGS_config);
+    <vino_people_msgs::ReidentificationSrv>>(service_name, FLAGS_config);
   
   slog::info << "Waiting for reid service request..." << slog::endl;
   ros::spin();

--- a/sample/src/image_segmentation_client.cpp
+++ b/sample/src/image_segmentation_client.cpp
@@ -24,7 +24,7 @@
 #include <ros/ros.h>
 #include "opencv2/opencv.hpp"
 
-#include <people_msgs/ObjectsInMasksSrv.h>
+#include <vino_people_msgs/ObjectsInMasksSrv.h>
 
 
 
@@ -34,10 +34,10 @@ int main(int argc, char ** argv)
 
   ros::NodeHandle n;
 
-  ros::ServiceClient client = n.serviceClient<people_msgs::ObjectsInMasksSrv>("/openvino_toolkit/service");
+  ros::ServiceClient client = n.serviceClient<vino_people_msgs::ObjectsInMasksSrv>("/openvino_toolkit/service");
 
 
-  people_msgs::ObjectsInMasksSrv srv;
+  vino_people_msgs::ObjectsInMasksSrv srv;
 
   if (client.call(srv))
   {

--- a/sample/src/image_segmentation_server.cpp
+++ b/sample/src/image_segmentation_server.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
 
 
   auto node = std::make_shared<vino_service::FrameProcessingServer
-    <people_msgs::ObjectsInMasksSrv>>(service_name, FLAGS_config);
+    <vino_people_msgs::ObjectsInMasksSrv>>(service_name, FLAGS_config);
   
   slog::info << "Waiting for seg service request..." << slog::endl;
   ros::spin();


### PR DESCRIPTION
people_msgs package name is changed to vino_people_msgs to avoid conflicting name with another native [people_msgs ros package](http://wiki.ros.org/people_msgs) during catkin_make. Only the directory name is kept as before `people_msgs`, while the package name and all references are changed to `vino_people_msgs`.