### PR TITLE
Make code clean

### DIFF
--- a/dynamic_vino_lib/include/dynamic_vino_lib/services/frame_processing_server.h
+++ b/dynamic_vino_lib/include/dynamic_vino_lib/services/frame_processing_server.h
@@ -28,6 +28,7 @@
 #include <people_msgs/EmotionSrv.h>
 #include <people_msgs/HeadPoseSrv.h>
 #include <people_msgs/PeopleSrv.h>
+#include <object_msgs/DetectObject.h>
 #include <object_msgs/DetectObjectRequest.h>
 #include <people_msgs/ObjectsInMasksSrv.h>
 #include <people_msgs/ReidentificationSrv.h>

--- a/dynamic_vino_lib/src/services/frame_processing_server.cpp
+++ b/dynamic_vino_lib/src/services/frame_processing_server.cpp
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <people_msgs/PeopleSrv.h>
-#include <people_msgs/ObjectsInMasksSrv.h>
-#include <people_msgs/ReidentificationSrv.h>
-#include <object_msgs/DetectObject.h>
-#include <object_msgs/DetectObjectRequest.h>
-#include <object_msgs/DetectObjectResponse.h>
-#include <pipeline_srv_msgs/PipelineSrv.h>
 #include <vino_param_lib/param_manager.h>
 #include <ros/ros.h>
 #include <ros/service_callback_helper.h>
@@ -28,11 +21,12 @@
 #include <chrono>
 #include <thread>
 
+#include "dynamic_vino_lib/services/frame_processing_server.h"
+
 #include "dynamic_vino_lib/pipeline_manager.h"
 #include "dynamic_vino_lib/pipeline.h"
 #include "dynamic_vino_lib/inputs/base_input.h"
 #include "dynamic_vino_lib/inputs/image_input.h"
-#include "dynamic_vino_lib/services/frame_processing_server.h"
 #include "dynamic_vino_lib/slog.h"
 
 namespace vino_service
@@ -79,9 +73,11 @@ bool FrameProcessingServer<T>::cbService(ros::ServiceEvent<typename T::Request, 
   {
     PipelineManager::PipelineData& p = pipelines_[it->second.params.name.c_str()];
     auto input = p.pipeline->getInputDevice();
+    
     Input::Config config;
     config.path = event.getRequest().image_path;
     input->config(config);
+
     p.pipeline->runOnce();
     auto output_handle = p.pipeline->getOutputHandle();
 

--- a/sample/src/image_object_client.cpp
+++ b/sample/src/image_object_client.cpp
@@ -43,7 +43,7 @@ int main(int argc, char** argv)
   ros::ServiceClient client = n.serviceClient<object_msgs::DetectObject>("/openvino_toolkit/service");
 
   object_msgs::DetectObject srv;
-  srv.request.image_paths = image_path;
+  srv.request.image_path = image_path;
 
   if (client.call(srv))
   {

--- a/sample/src/image_object_client.cpp
+++ b/sample/src/image_object_client.cpp
@@ -43,7 +43,7 @@ int main(int argc, char** argv)
   ros::ServiceClient client = n.serviceClient<object_msgs::DetectObject>("/openvino_toolkit/service");
 
   object_msgs::DetectObject srv;
-  srv.request.image_path = image_path;
+  srv.request.image_paths = image_path;
 
   if (client.call(srv))
   {
@@ -60,7 +60,8 @@ int main(int argc, char** argv)
          << srv.response.objects[0].objects_vector[i].object.probability * 100 << "%";
       ROS_INFO("%d: object: %s", i, srv.response.objects[0].objects_vector[i].object.object_name.c_str());
       ROS_INFO("prob: %f", srv.response.objects[0].objects_vector[i].object.probability);
-      ROS_INFO("location: (%d, %d, %d, %d)", srv.response.objects[0].objects_vector[i].roi.x_offset,
+      ROS_INFO("location: (%d, %d, %d, %d)", 
+               srv.response.objects[0].objects_vector[i].roi.x_offset,
                srv.response.objects[0].objects_vector[i].roi.y_offset,
                srv.response.objects[0].objects_vector[i].roi.width,
                srv.response.objects[0].objects_vector[i].roi.height);


### PR DESCRIPTION
Hi, I've modified frame_processing_server.cpp and frame_processing_server.h to make header file dependency clear. 
In `frame_processing_server.cpp`, I have deleted some code like `#include <people_msgs/XXX.h>`  which was appeared in  `frame_processing_server.h` already.